### PR TITLE
`mchain_receive_result_t` made tuple-like type

### DIFF
--- a/dev/so_5/mchain.hpp
+++ b/dev/so_5/mchain.hpp
@@ -965,6 +965,21 @@ class mchain_receive_result_t
 	};
 
 //
+/*!
+ * \brief part of tuple protocol for mchain_receive_result_t.
+ *
+ * \since v.5.8.5
+ */
+template<std::size_t Index>
+auto get(const mchain_receive_result_t& result)
+{
+	static_assert(Index < 3, "Index out of bounds for mchain_receive_result_t");
+	if constexpr (Index == 0) return result.extracted();
+	if constexpr (Index == 1) return result.handled();
+	if constexpr (Index == 2) return result.status();
+}
+
+//
 // mchain_send_result_t
 //
 /*!
@@ -2040,3 +2055,29 @@ receive(
 
 } /* namespace so_5 */
 
+namespace std
+{
+	//
+	/*!
+	 * \brief part of tuple protocol for mchain_receive_result_t.
+	 *
+	 * \since v.5.8.5
+	 */
+	template<>
+	struct tuple_size<so_5::mchain_receive_result_t>
+		: integral_constant<std::size_t, 3>
+	{
+	};
+
+	//
+	/*!
+	 * \brief part of tuple protocol for mchain_receive_result_t.
+	 *
+	 * \since v.5.8.5
+	 */
+	template<size_t Index>
+	struct tuple_element<Index, so_5::mchain_receive_result_t>
+		: tuple_element<Index, tuple<std::size_t, std::size_t, so_5::mchain_props::extraction_status_t>>
+	{
+	};
+}

--- a/dev/test/so_5/mchain/simple/main.cpp
+++ b/dev/test/so_5/mchain/simple/main.cpp
@@ -54,6 +54,11 @@ main()
 					UT_CHECK_CONDITION( 1 == r.extracted() );
 					UT_CHECK_CONDITION( 1 == r.handled() );
 					UT_CHECK_CONDITION( !hello_received );
+
+					const auto [extracted, handled, status] = r;
+					UT_CHECK_CONDITION(extracted == r.extracted());
+					UT_CHECK_CONDITION(handled == r.handled());
+					UT_CHECK_CONDITION(status == r.status());
 				}
 			},
 			20,


### PR DESCRIPTION
Hi!
I've just made `mchain_receive_result_t` a tuple-like type to enable structured bindings:

```cpp
const auto [extracted, handled, status] = receive(from(chain),...);
```

I found many scenarios this syntax can be useful when working with `receive`.

I have also added a check to a simple test on message chains that is already part of the codebase. I didn't take the liberty to impact the code more than that.

Please let me know if this makes sense for you and feel free to adapt the PR to your coding standards!